### PR TITLE
Added Support for MAX31850

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Original repository by Miles Burton: [Arduino-Temperature-Control-Library](https
 
 > This library supports the following devices:
 > 
-> 
+> * MAX31850 - New!
 > * DS18B20
 > * DS18S20 - Please note there appears to be an issue with this series.
 > * DS1822

--- a/firmware/spark-dallas-temperature.cpp
+++ b/firmware/spark-dallas-temperature.cpp
@@ -268,6 +268,9 @@ uint8_t DallasTemperature::getResolution(const uint8_t* deviceAddress)
         case TEMP_9_BIT:
             return 9;
         }
+        // special exception for MAX31850
+        if ((scratchPad[CONFIGURATION] & 0xF0) == 0xF0) 
+            return 12;
     }
     return 0;
 }
@@ -440,8 +443,11 @@ int16_t DallasTemperature::calculateTemperature(const uint8_t* deviceAddress, ui
                 ((scratchPad[COUNT_PER_C] - scratchPad[COUNT_REMAIN]) << 7) /
                   scratchPad[COUNT_PER_C]
             );
-
-    return fpTemperature;
+            
+    if (deviceAddress[0] == MAX31850MODEL && (scratchPad[0] & 0x1))
+        return NAN;
+    else 
+        return fpTemperature;
 }
 
 

--- a/firmware/spark-dallas-temperature.h
+++ b/firmware/spark-dallas-temperature.h
@@ -33,6 +33,7 @@
 #define DS18B20MODEL 0x28
 #define DS1822MODEL  0x22
 #define DS1825MODEL  0x3B
+#define MAX31850MODEL 0x3B
 
 // OneWire commands
 #define STARTCONVO      0x44  // Tells device to take a temperature reading and put it on the scratchpad


### PR DESCRIPTION
I merged the changes made by Adafruit to the Arduino Dallas Library here: 
https://learn.adafruit.com/adafruit-1-wire-thermocouple-amplifier-max31850k/wiring-and-test#download-arduino-libraries

No changes to the OneWire library (Spark Core or Arduino) are required for the MAX31850 for this to work (Adafruit just the changed the Arduino OneWire examples to process the data for the MAX31850).
