### PR TITLE
Update to spark-dallas-temperature.h

### DIFF
--- a/firmware/spark-dallas-temperature.h
+++ b/firmware/spark-dallas-temperature.h
@@ -63,7 +63,7 @@
 // Error Codes
 #define DEVICE_DISCONNECTED_C -127
 #define DEVICE_DISCONNECTED_F -196.6
-#define DEVICE_DISCONNECTED_RAW -2032
+#define DEVICE_DISCONNECTED_RAW -7040
 
 typedef uint8_t DeviceAddress[8];
 


### PR DESCRIPTION
Changed DEVICE_DISCONNECTED_RAW value from -2032 to -7040 as per https://github.com/milesburton/Arduino-Temperature-Control-Library/issues/22
