### PR TITLE
Fixed the OneWire Library reference for Particle devices.

### DIFF
--- a/firmware/spark-dallas-temperature.h
+++ b/firmware/spark-dallas-temperature.h
@@ -24,7 +24,7 @@
     #include <OneWire.h>
 #elif defined(SPARK) or defined(STM32F10X_MD)
     #include "application.h"
-    #include "../OneWire/OneWire.h"
+    #include <OneWire.h>
 #endif
 
 


### PR DESCRIPTION
The Particle Library system has changed, which broke this reference.